### PR TITLE
Fix require in gemspec

### DIFF
--- a/jdbc-hive2.gemspec
+++ b/jdbc-hive2.gemspec
@@ -1,5 +1,5 @@
 $LOAD_PATH << File.expand_path('../lib', __FILE__)
-require 'jdbc/hive2/version'
+require 'jdbc/hive2'
 
 Gem::Specification.new do |s|
   s.name        = 'jdbc-hive2'


### PR DESCRIPTION
The gemspec file was requiring 'jdbc/hive2/version' but that file
doesn't exist.  The VERSION constant lives in 'jdbc/hive2' instead
